### PR TITLE
Set up Chromatic visual regression workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,32 @@
+name: Visual regression tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 20.x
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@20c7e42e1b2f6becd5d188df9acb02f3e2f51519 # v13.2.0
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          autoAcceptChanges: main

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ yarn storybook
 
 Storybook starts on http://localhost:6006/.
 
+## Visual regression tests
+
+Chromatic powers visual regression testing for Storybook components.
+
+Locally run:
+
+```bash
+CHROMATIC_PROJECT_TOKEN=<your-project-token> yarn chromatic --exit-zero-on-changes
+```
+
+In CI, the `Visual regression tests` workflow publishes builds to Chromatic.  
+Add the `CHROMATIC_PROJECT_TOKEN` secret in the repository settings before enabling the workflow.
+
 ## Build & preview
 
 Build a production bundle with:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "vitest",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "chromatic": "chromatic"
   },
   "dependencies": {
     "react": "^19.0.0",
@@ -25,6 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "@vitejs/plugin-react": "^5.0.4",
+    "chromatic": "13.2.0",
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,6 +1154,11 @@ check-error@^2.1.1:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
   integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
+chromatic@13.2.0:
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-13.2.0.tgz#0ea8cf0cdd6397fb87b14bd46d4249f41e4d4361"
+  integrity sha512-7ikJxdpLdYa6zmd+nLoP1U0HX6oCCtyj2eiAMd0rD4L9kbkWpl1pVIyI3CUQ/lQLtD3VKMTVi+bI3cWD+qz/IA==
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"


### PR DESCRIPTION
This pull request introduces visual regression testing for Storybook components using Chromatic. It adds a new GitHub Actions workflow for automated visual regression tests on pushes and pull requests to `main`, updates documentation to explain the new testing process, and adds Chromatic as a dependency and script in the project configuration.

**Visual regression testing integration:**
* Added `.github/workflows/chromatic.yml` workflow to run Chromatic visual regression tests on pushes, pull requests, and manual triggers for the `main` branch.
* Updated `README.md` with instructions for running Chromatic locally and in CI, and guidance for configuring the required secret.

**Project configuration updates:**
* Added `chromatic` script to `package.json` for running visual regression tests locally.
* Added Chromatic (`chromatic@13.2.0`) to `devDependencies` in `package.json`.